### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you're using this repository in your research or applications, please cite us
 
 ## ⭐ Star History
 <div align="center">
-    <a href="https://star-history.com/#wjq-learning/CBraMod&Date">
-        <img src="https://api.star-history.com/svg?repos=wjq-learning/CBraMod&type=Date" style="width: 80%;" />
+    <a href="https://star-history.dera.page/#wjq-learning/CBraMod&Date">
+        <img src="https://star-history.dera.page/svg?repos=wjq-learning/CBraMod&type=Date" style="width: 80%;" />
     </a>
 </div>


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer displays correctly. This change points the chart to a working replacement so it renders as intended.